### PR TITLE
Issue where plugin is not deleting old disk properly after resizing operation

### DIFF
--- a/lib/vagrant/disksize/actions.rb
+++ b/lib/vagrant/disksize/actions.rb
@@ -44,7 +44,7 @@ module Vagrant
             unless File.exist? new_disk[:file]
               clone_as_vdi(driver, old_disk, new_disk)
               attach_disk(driver, new_disk)
-              File.delete(old_disk[:file])
+							remove_disk(driver, old_disk)
             end
           end
         end
@@ -79,6 +79,14 @@ module Vagrant
           port = parts[1]
           device = parts[2]
           driver.execute('storageattach', @machine.id, '--storagectl', controller, '--port', port, '--device', device, '--type', 'hdd',  '--medium', disk[:file])
+        end
+				
+				def remove_disk(driver, disk)
+          parts = disk[:name].split('-')
+          controller = parts[0]
+          port = parts[1]
+          device = parts[2]
+          driver.execute('closemedium', 'disk', disk[:uuid], '--delete')
         end
 
         def get_disk_size(driver, disk)

--- a/lib/vagrant/disksize/actions.rb
+++ b/lib/vagrant/disksize/actions.rb
@@ -44,7 +44,7 @@ module Vagrant
             unless File.exist? new_disk[:file]
               clone_as_vdi(driver, old_disk, new_disk)
               attach_disk(driver, new_disk)
-							remove_disk(driver, old_disk)
+              remove_disk(driver, old_disk)
             end
           end
         end
@@ -81,7 +81,7 @@ module Vagrant
           driver.execute('storageattach', @machine.id, '--storagectl', controller, '--port', port, '--device', device, '--type', 'hdd',  '--medium', disk[:file])
         end
 				
-				def remove_disk(driver, disk)
+        def remove_disk(driver, disk)
           parts = disk[:name].split('-')
           controller = parts[0]
           port = parts[1]


### PR DESCRIPTION
Steps to reproduce:

1. Add vagrant-disksize plugin
2. Add section to Vagrantfile to resize disk
  # resize disk
  if Vagrant.has_plugin?("vagrant-disksize")
    config.disksize.size = '40GB'
  end
3. run 'vagrant up' and wait for machine to come up
4. run 'vagrant destroy -f'
5. run 'vagrant up' again. At this point there should be an error message from Virtualbox similar to:
"Stderr: VBoxManage.EXE: error: UUID {9e51dfa3-b04f-4bf5-ac33-3358d8e30cff} of the medium 'Y:\VirtualboxVms\dev_box_x\box-disk001.vmdk' does not match the value {7d47d965-34d3-47ab-a738-e9cc4befb7c1} stored in the media registry ('C:\Users\<usr>\.VirtualBox\VirtualBox.xml')"


This is caused by not closing out the older disk in vboxmanage (closemedium) before deleting.

Created fork and PR to address issue.