### PR TITLE
[Issue 14] Ensure only real disks are dealt with (no CD/DVD/floppy)

### DIFF
--- a/lib/vagrant/disksize/actions.rb
+++ b/lib/vagrant/disksize/actions.rb
@@ -97,13 +97,15 @@ module Vagrant
           disk_keys = vminfo.keys.select { |k| k =~ /-ImageUUID-/ }
           disk_keys.each do |key|
             uuid = vminfo[key]
-            disk_name = key.gsub(/-ImageUUID-/,'-')
-            disk_file = vminfo[disk_name]
-            disks << {
-              uuid: uuid,
-              name: disk_name,
-              file: disk_file
-            }
+            if is_disk(driver, uuid)
+              disk_name = key.gsub(/-ImageUUID-/,'-')
+              disk_file = vminfo[disk_name]
+              disks << {
+                uuid: uuid,
+                name: disk_name,
+                file: disk_file
+              }
+            end
           end
           disks
         end
@@ -117,6 +119,15 @@ module Vagrant
             vminfo[key] = value
           end
           vminfo
+        end
+
+        def is_disk(driver, uuid)
+          begin
+            driver.execute("showmediuminfo", 'disk', uuid)
+            true
+          rescue
+            false
+          end
         end
 
         def generate_resizable_disk(disk)


### PR DESCRIPTION
This change creates method `is_disk`, which tests if a storage device is an actual disk. And this method is used by `identify_disks`, so that it only lists these disks, and not other storage devices.