### PR TITLE
[Issue 16] Implement proper removal of cloned disk

### DIFF
--- a/lib/vagrant/disksize/actions.rb
+++ b/lib/vagrant/disksize/actions.rb
@@ -44,7 +44,7 @@ module Vagrant
             unless File.exist? new_disk[:file]
               clone_as_vdi(driver, old_disk, new_disk)
               attach_disk(driver, new_disk)
-              File.delete(old_disk[:file])
+              remove_disk(driver, old_disk)
             end
           end
         end
@@ -79,6 +79,10 @@ module Vagrant
           port = parts[1]
           device = parts[2]
           driver.execute('storageattach', @machine.id, '--storagectl', controller, '--port', port, '--device', device, '--type', 'hdd',  '--medium', disk[:file])
+        end
+
+        def remove_disk(driver, disk)
+          driver.execute("closemedium", disk[:file], '--delete')
         end
 
         def get_disk_size(driver, disk)


### PR DESCRIPTION
This change creates a method, `remove_disk`, which fully erases a disk file and its VirtualBox reference after cloning