### PR TITLE
Fix for #20: Handle Windows file paths from WSL

### DIFF
--- a/lib/vagrant/disksize/actions.rb
+++ b/lib/vagrant/disksize/actions.rb
@@ -145,6 +145,7 @@ module Vagrant
 
         def generate_resizable_disk(disk)
           src = disk[:file]
+          src.gsub!(/\\+/, '/')
           src_extn = File.extname(src)
           src_path = File.dirname(src)
           src_base = File.basename(src, src_extn)


### PR DESCRIPTION
Running vagrant under WSL can confuse ruby as to how it should treat file paths. In this case it will treat the entire path as a filename, for example "C:\path\to\a\file.ext" will be parsed as
```
File.dirname(src) => "./"
File.basename(src) => "C:\path\to\a\file"
```

Replacing the back-slashes makes ruby recognize the windows path.